### PR TITLE
Patch out the misleading no-evaluation-compare message.

### DIFF
--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -30,8 +30,6 @@ eval.checkouttime %]s and evaluation took [% eval.evaltime %]s.</p>
 project=otherEval.jobset.project.name jobset=otherEval.jobset.name %] evaluation <a href="[%
 c.uri_for(c.controller('JobsetEval').action_for('view'),
 [otherEval.id]) %]">[% otherEval.id %]</a>.</p>
-[% ELSE %]
-<div class="alert alert-danger">Couldn't find an evaluation to compare to.</div>
 [% END %]
 
 <form>


### PR DESCRIPTION
This should avoid a red herring that sometimes comes up in the support channel when people have evaluation errors.

@iwanders 